### PR TITLE
Fix CloudFront origin update script to update TargetOriginId

### DIFF
--- a/docs/update_cloudfront_origin.sh
+++ b/docs/update_cloudfront_origin.sh
@@ -61,7 +61,7 @@ ETAG=$(aws cloudfront get-distribution-config --id "$DISTRIBUTION_ID" --query ET
 
 aws cloudfront get-distribution-config --id "$DISTRIBUTION_ID" \
   --query DistributionConfig \
-  | jq ".Origins.Items[0].DomainName = \"$NEW_DNS\" | .Origins.Items[0].Id = \"$NEW_DNS\"" \
+  | jq ".Origins.Items[0].DomainName = \"$NEW_DNS\" | .Origins.Items[0].Id = \"$NEW_DNS\" | .DefaultCacheBehavior.TargetOriginId = \"$NEW_DNS\"" \
   > /tmp/cf-config.json
 
 # CloudFront設定を更新


### PR DESCRIPTION
DefaultCacheBehavior.TargetOriginIdも新しいDNS名に更新するよう修正し、 CacheBehaviorとOriginの整合性を保つようにしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * CloudFront のオリジン切替スクリプトを改善し、デフォルトキャッシュ動作が新しいオリジンを確実に参照するよう修正。
  * 切替時の設定不整合を防止し、更新の一貫性と信頼性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->