### PR TITLE
Fix CachePolicy naming conflict in CloudFormation template

### DIFF
--- a/docs/ec2_code_server.yaml
+++ b/docs/ec2_code_server.yaml
@@ -425,7 +425,7 @@ Resources:
         MinTTL: 1
         Name:
           # prettier-ignore
-          !Join ['-', ['code-server', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+          !Join ['-', [!Ref AWS::StackName, 'cache-policy', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: all


### PR DESCRIPTION
スタック名を含めたユニークな名前にすることで、複数スタック作成時の
CachePolicy名の重複エラーを解消しました。